### PR TITLE
Fix error wrt changed API in imglib

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>34.0.0</version>
+		<version>38.0.1</version>
 		<relativePath />
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,13 @@
 		<license.licenseName>gpl_v3</license.licenseName>
 		<license.copyrightOwners>TrackMate developers.</license.copyrightOwners>
 
+		<imglib2.version>7.1.0</imglib2.version>
+		<imglib2-realtransform.version>4.0.3</imglib2-realtransform.version>
+		<imglib2-roi.version>0.15.0</imglib2-roi.version>
+		<imglib2-cache.version>1.0.0-beta-18</imglib2-cache.version>
+		<imglib2-algorithm.version>0.15.3</imglib2-algorithm.version>
+		<imglib2-ij.version>2.0.2</imglib2-ij.version>
+
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>sign,deploy-to-scijava</releaseProfiles>
 	</properties>

--- a/src/main/java/skeleton/Algorithms.java
+++ b/src/main/java/skeleton/Algorithms.java
@@ -202,7 +202,7 @@ public class Algorithms {
 			LabelRegion<Integer> centralObjectRegion, long[] dimensions) {
 		final Img<UnsignedByteType> centralObjectImg = ArrayImgs.unsignedBytes(dimensions);
 
-		final Cursor<Void> regionCursor = centralObjectRegion.cursor();
+		final Cursor<Void> regionCursor = centralObjectRegion.inside().cursor();
 		final RandomAccess<UnsignedByteType> access = centralObjectImg.randomAccess();
 		while (regionCursor.hasNext()) {
 			regionCursor.fwd();
@@ -215,7 +215,7 @@ public class Algorithms {
 	public static Img<BitType> createMaskFromLabelRegion(LabelRegion<Integer> region, long[] dimensions) {
 		final Img<BitType> centralObjectImg = ArrayImgs.bits(dimensions);
 
-		final Cursor<Void> regionCursor = region.cursor();
+		final Cursor<Void> regionCursor = region.inside().cursor();
 		final RandomAccess<BitType> access = centralObjectImg.randomAccess();
 		while (regionCursor.hasNext()) {
 			regionCursor.fwd();
@@ -838,7 +838,7 @@ public class Algorithms {
 			int label, LabelRegions<Integer> splitObjects) {
 		final long[] regionOffset = Intervals.minAsLongArray(labelRegions.getLabelRegion(label));
 		LabelRegion watershed = splitObjects.getLabelRegion(-1);
-		final LabelRegionCursor cursor = watershed.cursor();
+		final Cursor< Void > cursor = watershed.inside().cursor();
 		final RandomAccess<BitType> maskRandomAccess = mask.randomAccess();
 		long[] position = new long[watershed.numDimensions()];
 		while (cursor.hasNext()) {

--- a/src/main/java/skeleton/Regions.java
+++ b/src/main/java/skeleton/Regions.java
@@ -86,7 +86,7 @@ public abstract class Regions {
 		rai = Transforms.getWithAdjustedOrigin(labelRegion, rai);
 		final RandomAccess<BitType> randomAccess = rai.randomAccess();
 
-		final LabelRegionCursor cursor = labelRegion.cursor();
+		final Cursor< Void > cursor = labelRegion.inside().cursor();
 
 		while (cursor.hasNext()) {
 			cursor.fwd();
@@ -100,7 +100,7 @@ public abstract class Regions {
 	public static void drawRegionInMask(LabelRegion labelRegion, RandomAccessibleInterval<BitType> mask) {
 		final RandomAccess<BitType> maskAccess = mask.randomAccess();
 
-		final LabelRegionCursor cursor = labelRegion.cursor();
+		final Cursor< Void > cursor = labelRegion.inside().cursor();
 
 		while (cursor.hasNext()) {
 			cursor.fwd();
@@ -111,7 +111,7 @@ public abstract class Regions {
 
 	public static long size(LabelRegion labelRegion) {
 
-		final LabelRegionCursor cursor = labelRegion.cursor();
+		final Cursor< Void > cursor = labelRegion.inside().cursor();
 
 		long size = 0;
 		while (cursor.hasNext()) {
@@ -130,7 +130,7 @@ public abstract class Regions {
 
 		final RandomAccess<T> imageRandomAccess = image.randomAccess();
 		final RandomAccess<T> outputRandomAccess = output.randomAccess();
-		final LabelRegionCursor cursor = labelRegion.cursor();
+		final Cursor< Void > cursor = labelRegion.inside().cursor();
 
 		while (cursor.hasNext()) {
 			cursor.fwd();
@@ -196,7 +196,7 @@ public abstract class Regions {
 
 	private static <R extends RealType<R> & NativeType<R>> void drawRegion(RandomAccessibleInterval<R> img,
 			LabelRegion labelRegion, double value) {
-		final Cursor<Void> regionCursor = labelRegion.cursor();
+		final Cursor<Void> regionCursor = labelRegion.inside().cursor();
 		final RandomAccess<R> access = img.randomAccess();
 		while (regionCursor.hasNext()) {
 			regionCursor.fwd();
@@ -207,7 +207,7 @@ public abstract class Regions {
 
 	private static <T extends RealType<T> & NativeType<T>> void removeRegion(RandomAccessibleInterval<T> img,
 			LabelRegion labelRegion) {
-		final Cursor regionCursor = labelRegion.cursor();
+		final Cursor regionCursor = labelRegion.inside().cursor();
 		final RandomAccess<T> access = img.randomAccess();
 		while (regionCursor.hasNext()) {
 			regionCursor.fwd();
@@ -272,7 +272,7 @@ public abstract class Regions {
 		final RandomAccess<BitType> maskAccess = regionsMask.randomAccess();
 
 		for (LabelRegion region : regions) {
-			final Cursor<Void> regionCursor = region.cursor();
+			final Cursor<Void> regionCursor = region.inside().cursor();
 			while (regionCursor.hasNext()) {
 				regionCursor.fwd();
 				maskAccess.setPosition(regionCursor);
@@ -291,7 +291,7 @@ public abstract class Regions {
 		final RandomAccess<BitType> maskAccess = regionsMask.randomAccess();
 
 		for (LabelRegion region : regions) {
-			final Cursor<Void> regionCursor = region.cursor();
+			final Cursor<Void> regionCursor = region.inside().cursor();
 			while (regionCursor.hasNext()) {
 				regionCursor.fwd();
 				maskAccess.setPosition(regionCursor);

--- a/src/main/java/skeleton/Utils.java
+++ b/src/main/java/skeleton/Utils.java
@@ -789,7 +789,7 @@ public class Utils {
 	}
 
 	public static void drawObject(RandomAccessibleInterval<IntType> img, LabelRegion labelRegion, int value) {
-		final Cursor<Void> regionCursor = labelRegion.cursor();
+		final Cursor<Void> regionCursor = labelRegion.inside().cursor();
 		final RandomAccess<IntType> access = img.randomAccess();
 		BitType bitTypeTrue = new BitType(true);
 		while (regionCursor.hasNext()) {


### PR DESCRIPTION
In particular:
* IterableRegion no longer is IterableInterval but has nested `inside()` IterableInterval: https://github.com/imglib/imglib2-roi/pull/71

I would suggest to revisit and merge this when the new ImgLib2 `getType()` API  https://github.com/imglib/imglib2/pull/312 is merged and released